### PR TITLE
Get rid of 'Erase is backspace.' message

### DIFF
--- a/clyrics
+++ b/clyrics
@@ -188,7 +188,7 @@ sub clear_title {
 sub output_lyrics {
     my ($title) = @_;
 
-    system('reset') == 0 or print "\e[H\e[J\e[H";
+    system('reset -Q') == 0 or print "\e[H\e[J\e[H";
     print STDERR "** Title: <$title>\n" if DEBUG;
 
     my $lyrics = get_lyrics($title);


### PR DESCRIPTION
Calling 'reset' without '-Q' option may show 'Erase is backspace.' message after cleaning the screen. This pull request fixes that