### PR TITLE
Remove leading spaces from lyrics

### DIFF
--- a/clyrics
+++ b/clyrics
@@ -313,7 +313,7 @@ sub get_lyrics {
             warn $@ if ($DEBUG and $@);
 
             if (defined($text) and length($text) > 360) {
-                $text =~ s/^(?:\h*\R)+//;    # remove leading newlines
+                $text =~ s/^(?:\h*\R)+\h*//;    # remove leading newlines and spaces
                 return unpack 'A*', decode_entities($text);
             }
             else {


### PR DESCRIPTION
Often the first line of lyrics will end up indented by spaces, unlike the lines to follow. This tiny change trims that space (in addition to the empty lines already being trimmed).